### PR TITLE
Move up/down using Regex (uses Class#name syntax) [2012]

### DIFF
--- a/lib/pry-stack_explorer/commands.rb
+++ b/lib/pry-stack_explorer/commands.rb
@@ -153,8 +153,10 @@ module PryStackExplorer
         else
           if inc =~ /\d+/
             frame_manager.change_frame_to frame_manager.binding_index + inc.to_i
-          elsif match = /^([A-Z]+[^#.]*)(#|\.)(.+)$/.match(inc)
-            new_frame_index = find_frame_by_object_regex(Regexp.new(match[1]), Regexp.new(match[3]), :up)
+          elsif match = /^([A-Z]+[^#.]*)(#|\.)?(.*)$/.match(inc)
+            class_regex = Regexp.new(match[1])
+            method_regex = Regexp.new(match[3]) || /./
+            new_frame_index = find_frame_by_object_regex(class_regex, method_regex, :up)
             frame_manager.change_frame_to new_frame_index
           elsif inc =~ /^[^-].*$/
             new_frame_index = find_frame_by_regex(Regexp.new(inc), :up)
@@ -188,8 +190,10 @@ module PryStackExplorer
             else
               frame_manager.change_frame_to frame_manager.binding_index - inc.to_i
             end
-          elsif match = /^([A-Z]+[^#.]*)(#|\.)(.+)$/.match(inc)
-            new_frame_index = find_frame_by_object_regex(Regexp.new(match[1]), Regexp.new(match[3]), :down)
+          elsif match = /^([A-Z]+[^#.]*)(#|\.)?(.*)$/.match(inc)
+            class_regex = Regexp.new(match[1])
+            method_regex = Regexp.new(match[3]) || /./
+            new_frame_index = find_frame_by_object_regex(class_regex, method_regex, :down)
             frame_manager.change_frame_to new_frame_index 
           elsif inc =~ /^[^-].*$/
             new_frame_index = find_frame_by_regex(Regexp.new(inc), :down)
@@ -220,8 +224,10 @@ module PryStackExplorer
 
           if args[0] =~ /\d+/
             frame_manager.change_frame_to args[0].to_i
-          elsif match = /^([A-Z]+[^#.]*)(#|\.)(.+)$/.match(args[0])
-            new_frame_index = find_frame_by_object_regex(Regexp.new(match[1]), Regexp.new(match[3]), :up)
+          elsif match = /^([A-Z]+[^#.]*)(#|\.)?(.*)$/.match(args[0])
+            class_regex = Regexp.new(match[1])
+            method_regex = Regexp.new(match[3]) || /./
+            new_frame_index = find_frame_by_object_regex(class_regex, method_regex, :up)
             frame_manager.change_frame_to new_frame_index 
           elsif args[0] =~ /^[^-].*$/
             new_frame_index = find_frame_by_regex(Regexp.new(args[0]), :up)

--- a/test/test_commands.rb
+++ b/test/test_commands.rb
@@ -122,8 +122,8 @@ describe PryStackExplorer::Commands do
     end
 
 
-    describe 'by Class#method name regex' do
-      it 'should move to the method and class that matches the regex' do
+    describe 'by Class regex' do
+      it 'should move to the Class#method that matches the regex' do
         redirect_pry_io(InputTester.new("@method_list << self.class.to_s + '#' + __method__.to_s",
                                         'up Middle#bong',
                                         "@method_list << self.class.to_s + '#' + __method__.to_s",
@@ -134,10 +134,17 @@ describe PryStackExplorer::Commands do
         @top.method_list.should  == ['Bottom#bang', 'Middle#bong']
       end
 
-      ### ????? ###
-      # it 'should be case sensitive' do
-      # end
-      ### ????? ###
+      it 'should allow Class only syntax' do
+          redirect_pry_io(InputTester.new("@method_list << self.class.to_s + '#' + __method__.to_s",
+                                        'up Middle',
+                                        "@method_list << self.class.to_s + '#' + __method__.to_s",
+                                        "exit-all"), out=StringIO.new) do
+          @top.bing
+        end
+
+        @top.method_list.should == ['Bottom#bang', 'Middle#bong']
+
+      end
 
       it 'should allow partial class names' do
           redirect_pry_io(InputTester.new("@method_list << self.class.to_s + '#' + __method__.to_s",
@@ -255,10 +262,17 @@ describe PryStackExplorer::Commands do
         @top.method_list.should == ['Top#bing', 'Middle#bong']
       end
 
-      ### ????? ###
-      # it 'should be case sensitive' do
-      # end
-      ### ????? ###
+      it 'should allow Class only syntax' do
+        redirect_pry_io(InputTester.new('frame Top#bing',
+                                        "@method_list << self.class.to_s + '#' + __method__.to_s",
+                                        'down Middle',
+                                        "@method_list << self.class.to_s + '#' + __method__.to_s",
+                                        "exit-all"), out=StringIO.new) do
+          @top.bing
+        end
+
+        @top.method_list.should == ['Top#bing', 'Middle#bong']
+      end
 
       it 'should error if it cant find frame to match regex' do
         redirect_pry_io(InputTester.new('down Conrad#irwin',

--- a/test/test_commands.rb
+++ b/test/test_commands.rb
@@ -1,5 +1,39 @@
 require 'helper'
 
+
+class Top
+  attr_accessor :method_list, :middle
+  def initialize method_list
+    @method_list = method_list
+  end
+  def bing
+    @middle = Middle.new method_list
+    @middle.bong
+  end
+end
+
+class Middle
+  attr_accessor :method_list, :bottom
+  def initialize method_list
+    @method_list = method_list
+  end
+  def bong
+    @bottom = Bottom.new method_list
+    @bottom.bang
+  end
+end
+
+class Bottom
+  attr_accessor :method_list
+  def initialize method_list
+    @method_list = method_list
+  end
+  def bang
+    Pry.start(binding)
+  end
+end
+
+
 describe PryStackExplorer::Commands do
 
   before do
@@ -11,6 +45,9 @@ describe PryStackExplorer::Commands do
     def @o.bing() bong end
     def @o.bong() bang end
     def @o.bang() Pry.start(binding) end
+
+    method_list = []
+    @top = Top.new method_list
   end
 
   after do
@@ -83,6 +120,58 @@ describe PryStackExplorer::Commands do
         out.string.should =~ /Error: No frame that matches/
       end
     end
+
+
+    describe 'by Class#method name regex' do
+      it 'should move to the method and class that matches the regex' do
+        redirect_pry_io(InputTester.new("@method_list << self.class.to_s + '#' + __method__.to_s",
+                                        'up Middle#bong',
+                                        "@method_list << self.class.to_s + '#' + __method__.to_s",
+                                        "exit-all"), out=StringIO.new) do
+          @top.bing
+        end
+
+        @top.method_list.should  == ['Bottom#bang', 'Middle#bong']
+      end
+
+      ### ????? ###
+      # it 'should be case sensitive' do
+      # end
+      ### ????? ###
+
+      it 'should allow partial class names' do
+          redirect_pry_io(InputTester.new("@method_list << self.class.to_s + '#' + __method__.to_s",
+                                        'up Mid#bong',
+                                        "@method_list << self.class.to_s + '#' + __method__.to_s",
+                                        "exit-all"), out=StringIO.new) do
+          @top.bing
+        end
+
+        @top.method_list.should  == ['Bottom#bang', 'Middle#bong']
+
+      end
+
+      it 'should allow partial method names' do
+          redirect_pry_io(InputTester.new("@method_list << self.class.to_s + '#' + __method__.to_s",
+                                        'up Middle#bo',
+                                        "@method_list << self.class.to_s + '#' + __method__.to_s",
+                                        "exit-all"), out=StringIO.new) do
+          @top.bing
+        end
+
+        @top.method_list.should  == ['Bottom#bang', 'Middle#bong']
+
+      end
+
+      it 'should error if it cant find frame to match regex' do
+        redirect_pry_io(InputTester.new('up Conrad#irwin',
+                                        "exit-all"), out=StringIO.new) do
+          @top.bing
+        end
+
+        out.string.should =~ /Error: No frame that matches/
+      end
+    end
   end
 
   describe "down" do
@@ -147,6 +236,34 @@ describe PryStackExplorer::Commands do
                                         "down conrad_irwin",
                                         "exit-all"), out=StringIO.new) do
           @o.bing
+        end
+
+        out.string.should =~ /Error: No frame that matches/
+      end
+    end
+
+    describe 'by Class#method name regex' do
+      it 'should move to the method and class that matches the regex' do
+        redirect_pry_io(InputTester.new('frame Top#bing',
+                                        "@method_list << self.class.to_s + '#' + __method__.to_s",
+                                        'down Middle#bong',
+                                        "@method_list << self.class.to_s + '#' + __method__.to_s",
+                                        "exit-all"), out=StringIO.new) do
+          @top.bing
+        end
+
+        @top.method_list.should == ['Top#bing', 'Middle#bong']
+      end
+
+      ### ????? ###
+      # it 'should be case sensitive' do
+      # end
+      ### ????? ###
+
+      it 'should error if it cant find frame to match regex' do
+        redirect_pry_io(InputTester.new('down Conrad#irwin',
+                                        "exit-all"), out=StringIO.new) do
+          @top.bing
         end
 
         out.string.should =~ /Error: No frame that matches/


### PR DESCRIPTION
We added the feature @banister requested to use more specific syntax to jump stack frames.

This included a minor refactor of find_frame_by_regex in commands to avoid code duplication.
