### PR TITLE
Fix annoying warning on nil bindings.

### DIFF
--- a/lib/pry-stack_explorer.rb
+++ b/lib/pry-stack_explorer.rb
@@ -109,7 +109,7 @@ module PryStackExplorer
       !b1.nil? && !b2.nil? &&
         (b1.eval('self').equal?(b2.eval('self'))) &&
         (b1.eval('__method__') == b2.eval('__method__')) &&
-        (b1.eval('local_variables').map { |v| b1.eval("#{v}") }.equal?(
+        (b1.eval('local_variables').map { |v| b1.eval("#{v}") }.eql?(
          b2.eval('local_variables').map { |v| b2.eval("#{v}") }))
     end
   end

--- a/lib/pry-stack_explorer.rb
+++ b/lib/pry-stack_explorer.rb
@@ -106,7 +106,7 @@ module PryStackExplorer
     # @param [Binding] b2 Second binding.
     # @return [Boolean] Whether the `Binding`s are equal.
     def bindings_equal?(b1, b2)
-      b1 && b2 &&
+      !b1.nil? && !b2.nil? &&
         (b1.eval('self').equal?(b2.eval('self'))) &&
         (b1.eval('__method__') == b2.eval('__method__')) &&
         (b1.eval('local_variables').map { |v| b1.eval("#{v}") }.equal?(

--- a/lib/pry-stack_explorer.rb
+++ b/lib/pry-stack_explorer.rb
@@ -106,7 +106,8 @@ module PryStackExplorer
     # @param [Binding] b2 Second binding.
     # @return [Boolean] Whether the `Binding`s are equal.
     def bindings_equal?(b1, b2)
-      (b1.eval('self').equal?(b2.eval('self'))) &&
+      b1 && b2 &&
+        (b1.eval('self').equal?(b2.eval('self'))) &&
         (b1.eval('__method__') == b2.eval('__method__')) &&
         (b1.eval('local_variables').map { |v| b1.eval("#{v}") }.equal?(
          b2.eval('local_variables').map { |v| b2.eval("#{v}") }))

--- a/test/test_stack_explorer.rb
+++ b/test/test_stack_explorer.rb
@@ -396,9 +396,7 @@ describe PryStackExplorer do
         PryStackExplorer.bindings_equal?(nil, nil).should == false
         PryStackExplorer.bindings_equal?(nil, b).should == false
         PryStackExplorer.bindings_equal?(b, nil).should == false
-        # puts "\n#{b1} | #{b2} | #{bv1.equal? bv2} | #{bv1.eql? bv2} | #{bv1 == bv2}\n"
-        #⇒ #<Binding:0x000000035b0600> | #<Binding:0x000000035b0600> | false | true | true # WTF?
-        # PryStackExplorer.bindings_equal?(b, b).should == true
+        PryStackExplorer.bindings_equal?(b, b).should == true
       end
     end
   end

--- a/test/test_stack_explorer.rb
+++ b/test/test_stack_explorer.rb
@@ -389,5 +389,17 @@ describe PryStackExplorer do
         end
       end
     end
+
+    describe "PryStackExplorer.bindings_equal?" do
+      it "should return true if and only both bindings are defined and equal" do
+        b = 42.send :binding
+        PryStackExplorer.bindings_equal?(nil, nil).should == false
+        PryStackExplorer.bindings_equal?(nil, b).should == false
+        PryStackExplorer.bindings_equal?(b, nil).should == false
+        # puts "\n#{b1} | #{b2} | #{bv1.equal? bv2} | #{bv1.eql? bv2} | #{bv1 == bv2}\n"
+        #⇒ #<Binding:0x000000035b0600> | #<Binding:0x000000035b0600> | false | true | true # WTF?
+        # PryStackExplorer.bindings_equal?(b, b).should == true
+      end
+    end
   end
 end


### PR DESCRIPTION
Sometimes in Rails console I got an annoying error message on `nil` bindings. This is to safely eliminate them.
