### PR TITLE
⚠️ assigned but unused variable - frame_index

### DIFF
--- a/lib/pry-stack_explorer/commands.rb
+++ b/lib/pry-stack_explorer/commands.rb
@@ -125,7 +125,7 @@ module PryStackExplorer
         yield(b)
       end
 
-      frame_index = frame_manager.bindings.index(new_frame)
+      frame_manager.bindings.index(new_frame)
     end
   end
 


### PR DESCRIPTION
This patch eliminates a Ruby warning about unused variable.