### PR TITLE
require pry if not already defined

### DIFF
--- a/lib/pry-stack_explorer.rb
+++ b/lib/pry-stack_explorer.rb
@@ -1,6 +1,7 @@
 # pry-stack_explorer.rb
 # (C) John Mair (banisterfiend); MIT license
 
+require "pry" unless defined?(::Pry)
 require "pry-stack_explorer/version"
 require "pry-stack_explorer/commands"
 require "pry-stack_explorer/frame_manager"


### PR DESCRIPTION
Fixes https://github.com/pry/pry-stack_explorer/issues/30