### PR TITLE
Silence warning about __FILE__ and __LINE__ under ruby 2.7

### DIFF
--- a/lib/pry-stack_explorer.rb
+++ b/lib/pry-stack_explorer.rb
@@ -3,6 +3,7 @@
 
 require "pry" unless defined?(::Pry)
 require "pry-stack_explorer/version"
+require "pry-stack_explorer/location_helper"
 require "pry-stack_explorer/commands"
 require "pry-stack_explorer/frame_manager"
 require "pry-stack_explorer/when_started_hook"

--- a/lib/pry-stack_explorer/commands.rb
+++ b/lib/pry-stack_explorer/commands.rb
@@ -55,7 +55,7 @@ module PryStackExplorer
       sig = meth_obj ? "<#{signature_with_owner(meth_obj)}>" : ""
 
       self_clipped = "#{Pry.view_clip(b_self)}"
-      path = "@ #{b.eval('__FILE__')}:#{b.eval('__LINE__')}"
+      path = "@ #{LocationHelper.source_file(b)}:#{LocationHelper.source_line(b)}"
 
       if !verbose
         "#{type} #{desc} #{sig}"

--- a/lib/pry-stack_explorer/location_helper.rb
+++ b/lib/pry-stack_explorer/location_helper.rb
@@ -1,0 +1,19 @@
+module PryStackExplorer
+  # Ruby 2.6 introduced Binding.source_location, and Ruby 2.7 made it a warning
+  # to eval __FILE__ or __LINE__. This file exists to handle getting the file or
+  # line number silently regardless of ruby version.
+  module LocationHelper
+
+    module_function
+    def source_file(b = binding)
+      return b.source_location.first if b.respond_to?(:source_location)
+      b.eval("__FILE__")
+    end
+
+    module_function
+    def source_line(b = binding)
+      return b.source_location[1] if b.respond_to?(:source_location)
+      b.eval("__LINE__")
+    end
+  end
+end

--- a/lib/pry-stack_explorer/when_started_hook.rb
+++ b/lib/pry-stack_explorer/when_started_hook.rb
@@ -60,7 +60,7 @@ module PryStackExplorer
 
     # remove pry-nav / pry-debugger / pry-byebug frames
     def remove_debugger_frames(bindings)
-      bindings.drop_while { |b| b.eval("__FILE__") =~ /pry-(?:nav|debugger|byebug)/ }
+      bindings.drop_while { |b| LocationHelper.source_file(b) =~ /pry-(?:nav|debugger|byebug)/ }
     end
 
     # binding.pry frame


### PR DESCRIPTION
Fixes #43 by taking a similar approach to that taken by pry-byebug, making a helper module and then calling it when __FILE__ or __LINE__ would otherwise be referenced.

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>