### PR TITLE
Fixes for Ruby 2.6/2.7 and Pry 0.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Makefile
 doc/
 pkg/
 .yardoc/
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,9 @@ before_install:
   - gem update --system
 
 rvm:
-  - 1.9.3
-  - 2.0
-  - 2.1.10
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.5.3
+  - 2.6.6
+  - 2.7.1
   - ruby-head
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_install:
   - gem update --system
 
 rvm:
-  - 2.5.3
   - 2.6.6
   - 2.7.1
   - ruby-head

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+## v0.5.0 (X May 2020)
+* Should fix most deprecation warnings as of release
+* Require Pry 0.13
+* Fix Pry#_pry_ => #pry_instance deprecation
+
 ## v0.4.10 (X May 2020)
 * Require Ruby 2.6
 * Fix broken `show-stack` in Pry 0.13+

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,4 @@
+## v0.4.10 (X May 2020)
+* Require Ruby 2.6
+* Fix broken `show-stack` in Pry 0.13+
+* Fix Binding.source_location deprecations

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ After installing `pry-stack_explorer`, just start Pry as normal (typically via a
 
 Example:
 --------
-Here we run the following ruby script: 
+Here we run the following ruby script:
 ```Ruby
 require 'pry-stack_explorer'
 
@@ -61,6 +61,13 @@ Limitations
 
 * First release, so may have teething problems.
 * Limited to Rubinius, and MRI 1.9.2+ at this stage.
+
+Compatible versions
+-------------------
+* v0.5: Ruby 2.6+, Pry 0.13+
+* v0.4.10: Ruby 2.6+, Pry 0.12+
+* v0.4.9.3: Ruby 2.5 and older
+
 
 Contact
 -------

--- a/Rakefile
+++ b/Rakefile
@@ -33,12 +33,12 @@ end
 
 desc "run pry with plugin enabled"
 task :pry do
-  exec("pry -rubygems -I#{direc}/lib/ -r #{direc}/lib/#{PROJECT_NAME}")
+  exec("pry -I#{direc}/lib/ -r #{direc}/lib/#{PROJECT_NAME}")
 end
 
 desc "Run example"
 task :example do
-  sh "ruby -rubygems -I#{direc}/lib/ #{direc}/examples/example.rb "
+  sh "ruby -I#{direc}/lib/ #{direc}/examples/example.rb "
 end
 
 desc "Run example2"
@@ -61,7 +61,7 @@ task :default => :test
 
 desc "run tests"
 task :test do
-  sh "bacon -Itest -rubygems -a -q"
+  sh "bacon -Itest -a -q"
 end
 
 desc "generate gemspec"

--- a/lib/pry-stack_explorer.rb
+++ b/lib/pry-stack_explorer.rb
@@ -127,9 +127,9 @@ Pry.config.commands.import PryStackExplorer::Commands
 # monkey-patch the whereami command to show some frame information,
 # useful for navigating stack.
 Pry.config.hooks.add_hook(:before_whereami, :stack_explorer) do
-  if PryStackExplorer.frame_manager(_pry_) && !internal_binding?(target)
-    bindings      = PryStackExplorer.frame_manager(_pry_).bindings
-    binding_index = PryStackExplorer.frame_manager(_pry_).binding_index
+  if PryStackExplorer.frame_manager(pry_instance) && !internal_binding?(target)
+    bindings      = PryStackExplorer.frame_manager(pry_instance).bindings
+    binding_index = PryStackExplorer.frame_manager(pry_instance).binding_index
 
     output.puts "\n"
     output.puts "#{Pry::Helpers::Text.bold('Frame number:')} #{binding_index}/#{bindings.size - 1}"

--- a/lib/pry-stack_explorer/commands.rb
+++ b/lib/pry-stack_explorer/commands.rb
@@ -55,7 +55,7 @@ module PryStackExplorer
       sig = meth_obj ? "<#{signature_with_owner(meth_obj)}>" : ""
 
       self_clipped = "#{Pry.view_clip(b_self)}"
-      path = "@ #{b.eval('__FILE__')}:#{b.eval('__LINE__')}"
+      path = '@ ' + b.source_location.join(':')
 
       if !verbose
         "#{type} #{desc} #{sig}"

--- a/lib/pry-stack_explorer/commands.rb
+++ b/lib/pry-stack_explorer/commands.rb
@@ -5,13 +5,13 @@ module PryStackExplorer
     # @return [PryStackExplorer::FrameManager] The active frame manager for
     #   the current `Pry` instance.
     def frame_manager
-      PryStackExplorer.frame_manager(_pry_)
+      PryStackExplorer.frame_manager(pry_instance)
     end
 
     # @return [Array<PryStackExplorer::FrameManager>] All the frame
     #   managers for the current `Pry` instance.
     def frame_managers
-      PryStackExplorer.frame_managers(_pry_)
+      PryStackExplorer.frame_managers(pry_instance)
     end
 
     # @return [Boolean] Whether there is a context to return to once

--- a/lib/pry-stack_explorer/commands.rb
+++ b/lib/pry-stack_explorer/commands.rb
@@ -292,7 +292,7 @@ module PryStackExplorer
           output.puts "No caller stack available!"
         else
           content = ""
-          content << "\n#{text.bold("Showing all accessible frames in stack (#{frame_manager.bindings.size} in total):")}\n--\n"
+          content << "\n#{bold("Showing all accessible frames in stack (#{frame_manager.bindings.size} in total):")}\n--\n"
 
           base_frame_index, frames = selected_stack_frames
           frames.each_with_index do |b, index|

--- a/lib/pry-stack_explorer/version.rb
+++ b/lib/pry-stack_explorer/version.rb
@@ -1,3 +1,3 @@
 module PryStackExplorer
-  VERSION = '0.4.10'
+  VERSION = '0.5.0'
 end

--- a/lib/pry-stack_explorer/version.rb
+++ b/lib/pry-stack_explorer/version.rb
@@ -1,3 +1,3 @@
 module PryStackExplorer
-  VERSION = '0.4.9.3'
+  VERSION = '0.4.10'
 end

--- a/lib/pry-stack_explorer/when_started_hook.rb
+++ b/lib/pry-stack_explorer/when_started_hook.rb
@@ -60,7 +60,7 @@ module PryStackExplorer
 
     # remove pry-nav / pry-debugger / pry-byebug frames
     def remove_debugger_frames(bindings)
-      bindings.drop_while { |b| b.eval("__FILE__") =~ /pry-(?:nav|debugger|byebug)/ }
+      bindings.drop_while { |b| b.source_location[0] =~ /pry-(?:nav|debugger|byebug)/ }
     end
 
     # binding.pry frame

--- a/pry-stack_explorer.gemspec
+++ b/pry-stack_explorer.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |s|
   s.name = "pry-stack_explorer"
   s.version = "0.4.9.3"
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.required_rubygems_version = Gem::Requirement.new(">= 0")
   s.authors = ["John Mair (banisterfiend)"]
   s.date = Time.now.strftime('%Y-%m-%d')
   s.description = "Walk the stack in a Pry session"
@@ -13,24 +13,10 @@ Gem::Specification.new do |s|
   s.summary = "Walk the stack in a Pry session"
   s.test_files = ["test/helper.rb", "test/test_commands.rb", "test/test_frame_manager.rb", "test/test_stack_explorer.rb"]
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 4
+  s.specification_version = 4
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<binding_of_caller>, [">= 0.7"])
-      s.add_runtime_dependency(%q<pry>, [">= 0.9.11"])
-      s.add_development_dependency(%q<bacon>, ["~> 1.1.0"])
-      s.add_development_dependency(%q<rake>, ["~> 0.9"])
-    else
-      s.add_dependency(%q<binding_of_caller>, [">= 0.7"])
-      s.add_dependency(%q<pry>, [">= 0.9.11"])
-      s.add_dependency(%q<bacon>, ["~> 1.1.0"])
-      s.add_dependency(%q<rake>, ["~> 0.9"])
-    end
-  else
-    s.add_dependency(%q<binding_of_caller>, [">= 0.7"])
-    s.add_dependency(%q<pry>, [">= 0.9.11"])
-    s.add_dependency(%q<bacon>, ["~> 1.1.0"])
-    s.add_dependency(%q<rake>, ["~> 0.9"])
-  end
+  s.add_runtime_dependency(%q<binding_of_caller>, [">= 0.7"])
+  s.add_runtime_dependency(%q<pry>, [">= 0.9.11"])
+  s.add_development_dependency(%q<bacon>, ["~> 1.1.0"])
+  s.add_development_dependency(%q<rake>, ["~> 0.9"])
 end

--- a/pry-stack_explorer.gemspec
+++ b/pry-stack_explorer.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.specification_version = 4
 
   s.add_runtime_dependency(%q<binding_of_caller>, [">= 0.7"])
-  s.add_runtime_dependency(%q<pry>, [">= 0.9.11"])
+  s.add_runtime_dependency(%q<pry>, [">= 0.12.0"])
   s.add_development_dependency(%q<bacon>, ["~> 1.1.0"])
   s.add_development_dependency(%q<rake>, ["~> 0.9"])
 end

--- a/pry-stack_explorer.gemspec
+++ b/pry-stack_explorer.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.specification_version = 4
 
   s.add_runtime_dependency(%q<binding_of_caller>, [">= 0.7"])
-  s.add_runtime_dependency(%q<pry>, [">= 0.12.0"])
+  s.add_runtime_dependency(%q<pry>, [">= 0.13.0"])
   s.add_development_dependency(%q<bacon>, ["~> 1.1.0"])
   s.add_development_dependency(%q<rake>, ["~> 0.9"])
 end

--- a/pry-stack_explorer.gemspec
+++ b/pry-stack_explorer.gemspec
@@ -4,7 +4,8 @@ Gem::Specification.new do |s|
   s.name = "pry-stack_explorer"
   s.version = PryStackExplorer::VERSION
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0")
+  s.required_ruby_version = ">= 2.6.0"
+
   s.authors = ["John Mair (banisterfiend)"]
   s.date = Time.now.strftime('%Y-%m-%d')
   s.description = "Walk the stack in a Pry session"

--- a/pry-stack_explorer.gemspec
+++ b/pry-stack_explorer.gemspec
@@ -1,6 +1,8 @@
+require File.expand_path('../lib/pry-stack_explorer/version', __FILE__)
+
 Gem::Specification.new do |s|
   s.name = "pry-stack_explorer"
-  s.version = "0.4.9.3"
+  s.version = PryStackExplorer::VERSION
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0")
   s.authors = ["John Mair (banisterfiend)"]

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,8 +23,6 @@ class << Pry
     Pry.pager = false
     Pry.config.should_load_rc      = false
     Pry.config.should_load_plugins = false
-    Pry.config.history.should_load = false
-    Pry.config.history.should_save = false
     Pry.config.auto_indent         = false
     Pry.config.hooks               = Pry::Hooks.new
     Pry.config.collision_warning   = false


### PR DESCRIPTION
I volunteered some housekeeping, as this is a gem that's essential to me and that I appreciate a lot.

I was noticing a *lot* of warnings whenever I used:
* Tab completion
* `ls`
* Some Pry starts

`show-stack` was also broken as of Pry 0.13, following pry/pry#1865.

A few notes:

* My commits are very atomic. If one cares about eg using Ruby 2.5 or Pry 0.12, there is a commit that should get close to there. Everything is fixed in order.
* I've fixed some things with the test runner, but I do not understand how tests on the last release pass. I couldn't make `Pry.config.history.should_*=` work on any Pry version (0.9.11 to 0.13)
* This includes @karlwilbur's commit as-is in #46, credit where credit is due. Thanks Karl for getting the ball rolling! (cc #45)

As to leaving 2.5 behind, I figured it was simple to do it this way, and 2.5 users can always use 0.4.9.3. I left them a hint in the Readme if that happens. (2.5 is currently in security maintenance and going EOL in March 2021)

_(Edit: Thinking about it, we could probably branch off a version compatible with 2.5 with only cherry-picking the Pry 0.13 fixes - let me know if I can help with that)_

I don't understand the test failures, apologies for that. I didn't have the bandwidth to fix them up, unfortunately.

However, I've tested my changes on a real-world Rails app around 10+ times, trying different commands, and I couldn't find a single bug. It should be pretty solid. 

The changes are pretty simple, I'm fairly sure there are no regressions introduced.

---

Paging @kyrylo @banister @ConradIrwin 

Not sure how much time you have to dedicate to this,—and as a maintainer of another project I have no time for ;o)—, I'd personally feel pretty fine merging this knowing what I know. This is in my opinion ready to merge, maybe save a few sanity checks/confirmations.