### PR TITLE
Rename command to 'stack'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+* Rename 'show-stack' to 'stack' (#50, #8)
+
 ## v0.5.1 (21 May 2020)
 * Fix exception in started hook
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Unlike `ruby-debug`, pry-stack_explorer incurs no runtime cost and
 enables navigation right up the call-stack to the birth of the
 program.
 
-The `up`, `down`, `frame` and `show-stack` commands are provided. See
+The `up`, `down`, `frame` and `stack` commands are provided. See
 Pry's in-session help for more information on any of these commands.
 
 ## Usage
@@ -26,7 +26,7 @@ Provides commands available in Pry sessions.
 Commands:
 * `up`/`down` - Move up or down the call stack
 * `frame [n]` - Go to frame *n*
-* `show-stack` - Show call stack
+* `stack` - Show call stack
 
 
 ## Install

--- a/lib/pry-stack_explorer/commands.rb
+++ b/lib/pry-stack_explorer/commands.rb
@@ -237,7 +237,9 @@ module PryStackExplorer
       banner <<-BANNER
         Usage: stack [OPTIONS]
           Show all accessible stack frames.
-          e.g: show-stack -v
+          e.g: stack -v
+
+          alias: show-stack
       BANNER
 
       def options(opt)

--- a/lib/pry-stack_explorer/commands.rb
+++ b/lib/pry-stack_explorer/commands.rb
@@ -231,11 +231,11 @@ module PryStackExplorer
       end
     end
 
-    create_command "show-stack", "Show all frames" do
+    create_command "stack", "Show all frames" do
       include FrameHelpers
 
       banner <<-BANNER
-        Usage: show-stack [OPTIONS]
+        Usage: stack [OPTIONS]
           Show all accessible stack frames.
           e.g: show-stack -v
       BANNER
@@ -309,5 +309,8 @@ module PryStackExplorer
       end
 
     end
+
+    alias_command "show-stack", "stack"
+
   end
 end

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -49,6 +49,20 @@ describe "Commands" do
     Pry.config.hooks.delete_hook(:after_session, :delete_frame_manager)
   end
 
+  describe "stack" do
+    it "outputs the call stack" do
+      output = issue_pry_commands("stack"){ bingbong.bing }
+
+      expect(output).to match(/bang.*?bong.*?bing/m)
+    end
+
+    it "supports 'show-stack' as an alias" do
+      output = issue_pry_commands("show-stack"){ bingbong.bing }
+
+      expect(output).to match(/bang.*?bong.*?bing/m)
+    end
+  end
+
   describe "up" do
     it 'should move up the call stack one frame at a time' do
       redirect_pry_io(InputTester.new("@methods << __method__",

--- a/test/stack_explorer_test.rb
+++ b/test/stack_explorer_test.rb
@@ -99,7 +99,7 @@ describe PryStackExplorer do
 
     describe ":call_stack option" do
       it 'should invoke a session with the call stack set' do
-        redirect_pry_io(StringIO.new("show-stack\nexit\n"), out=StringIO.new) do
+        redirect_pry_io(StringIO.new("stack\nexit\n"), out=StringIO.new) do
           @o.bing
         end
 
@@ -112,7 +112,7 @@ describe PryStackExplorer do
         def o.bong() bang end
         def o.bang() Pry.start(binding, :call_stack => false) end
 
-        redirect_pry_io(StringIO.new("show-stack\nexit\n"), out=StringIO.new) do
+        redirect_pry_io(StringIO.new("stack\nexit\n"), out=StringIO.new) do
           o.bing
         end
 
@@ -125,7 +125,7 @@ describe PryStackExplorer do
         def o.beta() binding end
         def o.gamma() binding end
 
-        redirect_pry_io(StringIO.new("show-stack\nexit\n"), out=StringIO.new) do
+        redirect_pry_io(StringIO.new("stack\nexit\n"), out=StringIO.new) do
           Pry.start(binding, :call_stack => [o.beta, o.gamma, o.alpha])
         end
 


### PR DESCRIPTION
Following #8

- [x] Stray `show-stack` left behind

cc @banister 