### PR TITLE
Require Ruby 2.5 for v0.4.11

### DIFF
--- a/pry-stack_explorer.gemspec
+++ b/pry-stack_explorer.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.name = "pry-stack_explorer"
   s.version = PryStackExplorer::VERSION
 
-  s.required_ruby_version = ">= 2.0.0"
+  s.required_ruby_version = ">= 2.5.0"
   s.authors = ["John Mair (banisterfiend)"]
   s.email = "jrmair@gmail.com"
 


### PR DESCRIPTION
When I recently ran a `bundle update` on a project that is using Ruby 2.4, it suggested upgrading `pry-stack_explorer` to v0.4.11 as the latest version that supports Ruby 2.4.

However, the documentation says that v0.4.11 requires Ruby 2.5+. I tried running a build to check whether I could use it with Ruby 2.4, but [the tests failed](https://travis-ci.com/github/hosamaly/pry-stack_explorer/builds/179871034).

This pull request specifies Ruby 2.5 as a minimum requirement for the gem. It is targeted against the `works-with-ruby-2-5` branch so that it builds upon v4.x. Would it be possible to remove and re-publish v0.4.11 with an updated specification?