### PR TITLE
Keep pry-stack-explorer available with Ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ before_install:
 
 rvm:
   - 2.6.6
-  - 2.7.1
+  - 2.7.2
+  - 3.0.0
   - ruby-head
 
 matrix:

--- a/pry-stack_explorer.gemspec
+++ b/pry-stack_explorer.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.specification_version = 4
 
-  s.add_runtime_dependency 'binding_of_caller', '~> 0.7'
+  s.add_runtime_dependency 'binding_of_caller', '~> 1.0'
   s.add_runtime_dependency 'pry', '~> 0.13'
 
   s.add_development_dependency 'rspec', '~> 3.9'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,10 @@ Dir[File.expand_path("../support/**/*.rb", __FILE__)].each do |file|
   require file
 end
 
+if RUBY_VERSION >= '2.7.2'
+  # NOTE: https://bugs.ruby-lang.org/issues/17000
+  Warning[:deprecated] = true
+end
 
 # unless Object.const_defined? 'PryStackExplorer'
   $:.unshift File.expand_path '../../lib', __FILE__


### PR DESCRIPTION
Hi there,

Thanks a lot for maintaining this useful gem.

I happened to notice bundle install fails with this gem when I upgrade an application to Ruby3.
Looks like the dependent gem binding_of_caller has to be updated to 1.0.0  (the relevant PR can be found [here](https://github.com/banister/binding_of_caller/pull/81))

Also as Ruby 2.7 no longer emits deprecation warnings by default, I placed an explicit setting to turn that on in test environment.

Please advise if there's something I'm missing. I'm happy to work on it if any.
Hope that helps!