### PR TITLE
Update metadata to fix the links on rubygems.org

### DIFF
--- a/pry-stack_explorer.gemspec
+++ b/pry-stack_explorer.gemspec
@@ -17,6 +17,10 @@ Gem::Specification.new do |s|
   s.files = `git ls-files lib *.md LICENSE`.split("\n")
 
   s.homepage = "https://github.com/pry/pry-stack_explorer"
+  s.metadata = {
+    "bug_tracker_uri" => "https://github.com/pry/pry-stack_explorer/issues",
+    "source_code_uri" => "https://github.com/pry/pry-stack_explorer",
+  }
 
   s.specification_version = 4
 


### PR DESCRIPTION

The following links on the RubyGems page is the URLs of the old repository (banister/pry-stack_explorer). 
- Source Code
- Bug Tracker

https://rubygems.org/gems/pry-stack_explorer

This PR will fix the problem.

---
Ref:
https://guides.rubygems.org/specification-reference/#metadata