### PR TITLE
Keep pry-stack_explorer working with Ruby 4.x

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,9 +24,9 @@ def apply_spec_defaults(s)
   s.email = 'jrmair@gmail.com'
   s.description = s.summary
   s.require_path = 'lib'
-  s.add_dependency("binding_of_caller",">= 0.7")
-  s.add_dependency("pry",">=0.9.11")
-  s.add_development_dependency("bacon","~>1.1.0")
+  s.add_dependency("binding_of_caller",">= 1.0")
+  s.add_dependency("pry","~> 0.13")
+  s.add_development_dependency("rspec","~> 3.9")
   s.add_development_dependency('rake', '~> 0.9')
   s.homepage = "https://github.com/pry/pry-stack_explorer"
   s.files = `git ls-files`.split("\n")

--- a/pry-stack_explorer.gemspec
+++ b/pry-stack_explorer.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.specification_version = 4
 
-  s.add_runtime_dependency 'binding_of_caller', '~> 1.0'
+  s.add_runtime_dependency 'binding_of_caller', '>= 1.0'
   s.add_runtime_dependency 'pry', '~> 0.13'
 
   s.add_development_dependency 'rspec', '~> 3.9'


### PR DESCRIPTION
binding_of_caller 2.0.0 or greater is needed for Ruby 4 support, so change the gemspec requirement to require greater-than 1.0 rather than same-major-version as 1.0.

binding_of_caller 2.0.0 stops supporting Ruby 2.6 and below, but in that case we should still be able to use binding_of_caller 1.0.1 which does support Ruby 2.6. - which is why I've changed it to `>= 1.0` rather than `~> 2.0`

Also updates Rakefile to match the pry-stack_explorer.gemspec

Also see https://github.com/pry/pry-stack_explorer/issues/62